### PR TITLE
[#18] feat: 참여자 목록 컴포넌트 구현 및 scrollArea shadcn/ui 설치

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-scroll-area": "^1.2.10",
         "@tanstack/react-query": "^5.90.10",
         "axios": "^1.13.2",
         "class-variance-authority": "^0.7.1",
@@ -1235,6 +1236,18 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-avatar": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz",
@@ -1289,6 +1302,45 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
@@ -1307,6 +1359,93 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -6474,6 +6613,7 @@
       "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
       "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-scroll-area": "^1.2.10",
     "@tanstack/react-query": "^5.90.10",
     "axios": "^1.13.2",
     "class-variance-authority": "^0.7.1",

--- a/src/components/participant/ParticipantItem.tsx
+++ b/src/components/participant/ParticipantItem.tsx
@@ -1,0 +1,51 @@
+import Profile from "../Profile";
+import { cn } from "@/lib/utils";
+import Button from "../Button";
+import { Minus } from "lucide-react";
+import { Participant, ParticipantListMode } from "./type";
+
+interface ParticipantItemProps {
+    mode: ParticipantListMode;
+    participant: Participant;
+}
+
+const ParticipantItem = ({ mode, participant }: ParticipantItemProps) => {
+    const { name, profileImageUrl, removable, isExisting, role } = participant;
+
+    const showDeleteBtn =
+        mode === "read"
+            ? false
+            : mode === "invite"
+            ? removable
+            : mode === "delete" && role !== "LEADER"
+            ? true
+            : false;
+
+    return (
+        <li
+            className={cn(
+                "flex items-center gap-2 px-3 py-1 rounded-md cursor-pointer hover:bg-gray1/40",
+                mode === "invite" && isExisting
+                    ? "bg-sub1/40 hover:bg-sub1/40"
+                    : "bg-white"
+            )}
+        >
+            <div className="relative">
+                {showDeleteBtn && (
+                    <Button
+                        variant="disable"
+                        icon={<Minus className="w-2" />}
+                        size="sm"
+                        className="w-0.5 h-0.5 absolute -top-0.5 -right-1.5 z-10"
+                    />
+                )}
+                <Profile size="sm" imageUrl={profileImageUrl} />
+            </div>
+            <span className="text-xs overflow-hidden text-ellipsis">
+                {name}
+            </span>
+        </li>
+    );
+};
+
+export default ParticipantItem;

--- a/src/components/participant/ParticipantList.tsx
+++ b/src/components/participant/ParticipantList.tsx
@@ -1,0 +1,43 @@
+import ParticipantItem from "./ParticipantItem";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Participant, ParticipantListMode } from "./type";
+import { cn } from "@/lib/utils";
+
+type Hight = "sm" | "md" | "lg" | "auto";
+
+interface ParticipantListProps {
+    mode: ParticipantListMode;
+    participants: Participant[];
+    hight: Hight;
+    className?: string;
+}
+
+const hightClasses: Record<Hight, string> = {
+    sm: "h-20",
+    md: "h-24",
+    lg: "h-48",
+    auto: "h-auto",
+};
+
+const ParticipantList = ({
+    mode,
+    participants,
+    hight = "md",
+    className,
+}: ParticipantListProps) => {
+    return (
+        <ScrollArea className={cn(className, hightClasses[hight], "w-[420px]")}>
+            <ul className="grid grid-cols-3 gap-1 mr-4">
+                {participants.map((user) => (
+                    <ParticipantItem
+                        key={user.userId}
+                        participant={user}
+                        mode={mode}
+                    />
+                ))}
+            </ul>
+        </ScrollArea>
+    );
+};
+
+export default ParticipantList;

--- a/src/components/participant/type.ts
+++ b/src/components/participant/type.ts
@@ -1,0 +1,11 @@
+export type ParticipantListMode = "read" | "invite" | "delete";
+
+export interface Participant {
+    userId: number;
+    name: string;
+    email: string;
+    profileImageUrl: string | null;
+    role: string;
+    removable: boolean;
+    isExisting: boolean;
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }


### PR DESCRIPTION
## 🔗 이슈
closes #18 

## ⚙️ 작업 내용
참여자 목록 컴포넌트 구현
shandcn/ui scrollArea 가져와 스크롤 사용
List, Item 으로 컴포넌트를 나누고 3곳에서 다른 방식으로 사용되므로 mode 타입을 만들어둠
`export type ParticipantListMode = "read" | "invite" | "delete";`
참여자의 role, removable, isExisting 에 따라 이미 참여중인 사용자, 삭제 가능한 사용자를 나눌 수 있도록 함

사용 시
`<ParticipantList hight="md" mode="read" participants={uses} />`

## 🗒️ 기타 참고사항
mock data 예시
```
{
        userId: 7,
        name: "사용자이름7",
        role: "MEMBER",
        email: "aaa@aaa.com",
        profileImageUrl: "https://...",
        removable: true, // 리더만 fasle, 삭제 여부 -> mode 가 delete 면 리더 제외하고 모두 removable, mode 가 invite 이면 사용자 추가 시 true 로 구분
        isExisting: false, // 참여자 목록 가져오면 존재하면 true, 임시로 추가한 사용자면 false 로 구분
}
