### PR TITLE
[#30] feat: Label 컴포넌트 구현

### DIFF
--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,0 +1,64 @@
+import { cn } from "../lib/utils";
+
+type variant = "default" | "red" | "blue" | "green" | "black" | "white";
+type size = "xs" | "sm" | "md";
+
+interface LabelProps {
+    label: string;
+    variant?: variant;
+    size?: size;
+    className?: string;
+    leftIcon?: React.ReactNode;
+    onClick?: () => void;
+}
+
+const sizeClasses: Record<size, string> = {
+    xs: "px-1.5 py-1 text-[10px]",
+    sm: "px-2 py-1.5 text-xs",
+    md: "px-3 py-2 text-sm",
+};
+
+const variantClasses: Record<variant, string> = {
+    default: "bg-gray1 text-black",
+    red: "bg-sub2/20 text-red-400",
+    blue: "bg-sub3/30 text-blue-500",
+    green: "bg-sub4/40 text-green-600",
+    black: "bg-gray5 text-white",
+    white: "bg-white border text-black",
+};
+
+const Label = ({
+    label,
+    variant = "default",
+    size = "sm",
+    className,
+    leftIcon,
+    onClick,
+}: LabelProps) => {
+    const Component = onClick ? "button" : "div";
+
+    return (
+        <Component
+            className={cn(
+                "rounded-full inline-flex items-center",
+                sizeClasses[size],
+                variantClasses[variant],
+                onClick && "cursor-pointer",
+                className
+            )}
+            type={onClick ? "button" : undefined}
+            onClick={onClick}
+        >
+            {leftIcon ? (
+                <span className="flex items-center gap-2">
+                    {leftIcon}
+                    {label}
+                </span>
+            ) : (
+                <span>{label}</span>
+            )}
+        </Component>
+    );
+};
+
+export default Label;


### PR DESCRIPTION
## 🔗 이슈
#30 

## ⚙️ 작업 내용
Label 컴포넌트가 Board, Task 상세페이지에서 사용되므로
읽기용, 버튼용으로 필요하므로 onClick Prop 에 따라 button, div 태그로 바뀌도록 구현

<img width="240" height="48" alt="스크린샷 2025-11-21 오전 11 58 37" src="https://github.com/user-attachments/assets/1c52b5b1-9184-462a-bdb7-6087852ce7b5" />


## 🗒️ 기타 참고사항
Profile 을 leftIocn 에 넣어서 임의 크기를 크기를 조정하면 Label size 를 sm이나 md 등으로 줘도 Profile 크기에 따라 size 가 조금 늘어날 수 있습니다.
