### PR TITLE
[#36] feat: PageHeader 컴포넌트 구현

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils";
+import React from "react";
+
+interface PageHeaderProps {
+    left: string;
+    center?: React.ReactNode;
+    right?: React.ReactNode;
+    className?: string;
+}
+
+const PageHeader = ({ left, center, right, className }: PageHeaderProps) => {
+    return (
+        <header
+            className={cn(
+                "px-8 py-4 flex justify-between items-center bg-white",
+                className
+            )}
+        >
+            <div>
+                <h2 className="text-2xl font-bold">{left}</h2>
+            </div>
+            <div className="flex-1 flex justify-center">{center}</div>
+            <div>{right}</div>
+        </header>
+    );
+};
+
+export default PageHeader;


### PR DESCRIPTION
## 🔗 이슈
#36 

## ⚙️ 작업 내용
페이지별 비슷하게 Title 이 들어가 페이지마다 재사용할 수 있게 컴포넌트 구현

<img width="1139" height="97" alt="스크린샷 2025-11-22 오후 5 50 21" src="https://github.com/user-attachments/assets/4a14b8cb-3fcd-4468-a0a3-ac43b50ebb14" />


## 🗒️ 기타 참고사항
전체 Header 보다 padding 더 줘서 좀 더 안쪽으로 배치했습니다.
추후 Header 와 동일하게 맞추고 싶다면 className prop (px-4 등) 으로 값을 넣어주면 됩니다.
