### PR TITLE
[#48] Refactor: Label 색 변경에 따른 Label 컴포넌트 수정 및 Board 수정

### DIFF
--- a/src/app/board/StateTaskCard.tsx
+++ b/src/app/board/StateTaskCard.tsx
@@ -1,20 +1,17 @@
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
-import Label from "@/components/Label";
+import Label, { LabelVariant } from "@/components/Label";
 import Profile from "@/components/Profile";
 import { MessageSquareText, Plus } from "lucide-react";
-import { Priority, StateDataProps } from "./type";
+import { LabelColorType, StateDataProps } from "./type";
 
-type color = "red" | "green" | "default";
-
-const PRIORITY_VARIANT_MAP: Record<Priority, color> = {
-    HIGH: "red",
-    MEDIUM: "green",
-    LOW: "default",
+const LABEL_COLOR_MAP: Record<LabelColorType, LabelVariant> = {
+  RED: "red",
+  YELLOW: "yellow",
+  GRAY: "default",
 };
-
 const StateTaskCard = ({
     title,
-    priority,
+    label,
     assigneeProfileImageUrl,
     participantProfileImageUrls,
     commentCount,
@@ -27,8 +24,8 @@ const StateTaskCard = ({
                         {title}
                     </h4>
                     <Label
-                        label={priority}
-                        variant={PRIORITY_VARIANT_MAP[priority]}
+                        text={label.labelName}
+                        variant={LABEL_COLOR_MAP[label.color]}
                         size="sm"
                     />
                 </CardContent>

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -14,7 +14,7 @@ const Board = () => {
         },
         {
             label: "중요도",
-            value: "priority",
+            value: "label",
         },
         {
             label: "사용자명",
@@ -33,7 +33,10 @@ const Board = () => {
             {
                 taskId: 10,
                 title: "로그인 페이지 UI",
-                priority: "HIGH",
+                label: {
+                  labelName: "HIGH",
+                  color: "RED"
+                },
                 assigneeProfileImageUrl: "https://...",
                 participantProfileImageUrls: [
                     "https://...",
@@ -45,7 +48,10 @@ const Board = () => {
             {
                 taskId: 11,
                 title: "로그인 페이지 UI",
-                priority: "LOW",
+                label: {
+                  labelName: "MEDIUM",
+                  color: "YELLOW"
+                },
                 assigneeProfileImageUrl: "https://...",
                 participantProfileImageUrls: [],
                 commentCount: 3,
@@ -55,7 +61,10 @@ const Board = () => {
             {
                 taskId: 8,
                 title: "로그인 페이지 UI",
-                priority: "MEDIUM",
+                label: {
+                  labelName: "MEDIUM",
+                  color: "YELLOW"
+                },
                 assigneeProfileImageUrl: "https://...",
                 participantProfileImageUrls: ["https://..."],
                 commentCount: 3,
@@ -66,7 +75,10 @@ const Board = () => {
             {
                 taskId: 4,
                 title: "로그인 페이지 UI",
-                priority: "LOW",
+                label: {
+                  labelName: "LOW",
+                  color: "GRAY"
+                },
                 assigneeProfileImageUrl: "https://...",
                 participantProfileImageUrls: ["https://..."],
                 commentCount: 3,

--- a/src/app/board/type.ts
+++ b/src/app/board/type.ts
@@ -1,9 +1,14 @@
-export type Priority = "HIGH" | "MEDIUM" | "LOW";
+export type LabelName = "HIGH" | "MEDIUM" | "LOW";
+export type LabelColorType = "RED" | "YELLOW" | "GRAY";
+export interface LabelItem {
+  labelName: LabelName;
+  color: LabelColorType;
+}
 
 export interface StateDataProps {
     taskId: number;
     title: string;
-    priority: Priority;
+    label: LabelItem;
     assigneeProfileImageUrl: string;
     participantProfileImageUrls: string[];
     commentCount: number;

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,10 +1,10 @@
 import { cn } from "../lib/utils";
 
-export type LabelVariant = "default" | "red" | "blue" | "green" | "black" | "white";
+export type LabelVariant = "default" | "red" | "blue" | "green" | "black" | "white" | "yellow";
 type size = "xs" | "sm" | "md";
 
 interface LabelProps {
-    label: string;
+    text: string;
     variant?: LabelVariant;
     size?: size;
     className?: string;
@@ -19,16 +19,17 @@ const sizeClasses: Record<size, string> = {
 };
 
 const variantClasses: Record<LabelVariant, string> = {
-    default: "bg-gray1 text-black",
+    default: "bg-gray1 text-black/60",
     red: "bg-sub2/20 text-red-400",
     blue: "bg-sub3/30 text-blue-500",
     green: "bg-sub4/40 text-green-600",
     black: "bg-gray5 text-white",
     white: "bg-white border text-black",
+    yellow: "bg-yellow-200/70  text-yellow-600"
 };
 
 const Label = ({
-    label,
+    text,
     variant = "default",
     size = "sm",
     className,
@@ -52,10 +53,10 @@ const Label = ({
             {leftIcon ? (
                 <span className="flex items-center gap-2">
                     {leftIcon}
-                    {label}
+                    {text}
                 </span>
             ) : (
-                <span>{label}</span>
+                <span>{text}</span>
             )}
         </Component>
     );


### PR DESCRIPTION
## 🔗 이슈
#47 #48 

## ⚙️ 작업 내용
### before
 - 기존 Label 에서 yellow color 값 없음
 - Label 컴포넌트 내 prop 값이 label 이여서 겹쳐서 헷갈림
 - Board 컴포넌트에서 prop 가 priority
### after
 - yellow color 값 추가
 - Label 컴포넌트 내 label -> text 로 변경
 - Board 에서 label 이 아닌 priority 로 이름을 지정해줘서 이 부분을 label 로 바꾸고 label, color 값을 고정적으로 줌
```
export type LabelName = "HIGH" | "MEDIUM" | "LOW";
export type LabelColorType = "RED" | "YELLOW" | "GRAY";
export interface LabelItem {
  labelName: LabelName;
  color: LabelColorType;
}
```


## 🗒️ 기타 참고사항
없음
