### PR TITLE
[#43] feat: task editor,viewer Modal UI 구현 및 일부 기능 구현을 위한 popover, label, board, userInfoModal 수정

### DIFF
--- a/src/app/board/StateSection.tsx
+++ b/src/app/board/StateSection.tsx
@@ -2,14 +2,14 @@ import StateTaskCard from "./StateTaskCard";
 import { StateDataProps } from "./type";
 
 interface StateSectionProps {
-    state: string;
+    status: string;
     tasks: StateDataProps[];
 }
 
-const StateSection = ({ state, tasks }: StateSectionProps) => {
+const StateSection = ({ status, tasks }: StateSectionProps) => {
     return (
         <section className="flex-1 min-w-[200px]">
-            <h3 className="mb-3 ml-1 text-xl text-gray5 font-bold">{state}</h3>
+            <h3 className="mb-3 ml-1 text-xl text-gray5 font-bold">{status}</h3>
             <ul className="bg-gray1/80 p-4 rounded-xl flex flex-col gap-3">
                 {tasks.map((item) => (
                     <StateTaskCard key={item.taskId} {...item} />

--- a/src/app/board/StateTaskCard.tsx
+++ b/src/app/board/StateTaskCard.tsx
@@ -1,67 +1,85 @@
+"use client";
+
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
-import Label, { LabelVariant } from "@/components/Label";
+import Label from "@/components/Label";
 import Profile from "@/components/Profile";
 import { MessageSquareText, Plus } from "lucide-react";
-import { LabelColorType, StateDataProps } from "./type";
+import { StateDataProps } from "./type";
+import TaskDetailModal from "@/components/task/TaskViewerModal";
+import { useState } from "react";
+import { LABEL_OPTIONS } from "@/components/task/labelOptions";
 
-const LABEL_COLOR_MAP: Record<LabelColorType, LabelVariant> = {
-  RED: "red",
-  YELLOW: "yellow",
-  GRAY: "default",
-};
-const StateTaskCard = ({
-    title,
-    label,
-    assigneeProfileImageUrl,
-    participantProfileImageUrls,
-    commentCount,
-}: StateDataProps) => {
+const StateTaskCard = (task: StateDataProps) => {
+    const {
+        taskId,
+        title,
+        label,
+        assigneeProfileImageUrl,
+        participantProfileImageUrls,
+        commentCount,
+    } = task;
+    const [isTaskViewerModalOpen, setIsTaskViewerModalOpen] = useState(false);
+
+    const labelData = LABEL_OPTIONS.find(
+        (option) => option.value === label.labelName
+    );
+
     return (
-        <li className="cursor-pointer">
-            <Card className="px-0 py-4 gap-10">
-                <CardContent>
-                    <h4 className="mb-3 whitespace-nowrap overflow-hidden text-ellipsis">
-                        {title}
-                    </h4>
-                    <Label
-                        text={label.labelName}
-                        variant={LABEL_COLOR_MAP[label.color]}
-                        size="sm"
-                    />
-                </CardContent>
-                <CardFooter className="flex justify-between text-gray3">
-                    <div className="flex items-center">
-                        <MessageSquareText size={18} className="mr-1.5" />
-                        <p>{commentCount}</p>
-                    </div>
-                    <div className="flex-row-reverse relative translate-x-6 hidden xl:flex">
-                        {assigneeProfileImageUrl && (
-                            <Profile
-                                imageUrl={assigneeProfileImageUrl}
-                                className="size-10 border-4 border-white -translate-x-4"
-                            />
-                        )}
-                        {participantProfileImageUrls.length >= 1 && (
-                            <Profile
-                                imageUrl={participantProfileImageUrls[0]}
-                                className="size-10 border-4 border-white -translate-x-2"
-                            />
-                        )}
-                        {participantProfileImageUrls.length >= 2 && (
-                            <Profile
-                                imageUrl={participantProfileImageUrls[1]}
-                                className="size-10 border-4 border-white"
-                            />
-                        )}
-                        {participantProfileImageUrls.length > 2 ? (
-                            <Plus size={14} className="translate-x-26" />
-                        ) : (
-                            <></>
-                        )}
-                    </div>
-                </CardFooter>
-            </Card>
-        </li>
+        <>
+            <li className="cursor-pointer">
+                <Card
+                    className="px-0 py-4 gap-10"
+                    onClick={() => setIsTaskViewerModalOpen(true)}
+                >
+                    <CardContent>
+                        <h4 className="mb-3 whitespace-nowrap overflow-hidden text-ellipsis">
+                            {title}
+                        </h4>
+                        <Label
+                            text={label.labelName}
+                            variant={labelData?.variant}
+                            size="sm"
+                        />
+                    </CardContent>
+                    <CardFooter className="flex justify-between text-gray3">
+                        <div className="flex items-center">
+                            <MessageSquareText size={18} className="mr-1.5" />
+                            <p>{commentCount}</p>
+                        </div>
+                        <div className="flex-row-reverse relative translate-x-6 hidden xl:flex">
+                            {assigneeProfileImageUrl && (
+                                <Profile
+                                    imageUrl={assigneeProfileImageUrl}
+                                    className="size-10 border-4 border-white -translate-x-4"
+                                />
+                            )}
+                            {participantProfileImageUrls.length >= 1 && (
+                                <Profile
+                                    imageUrl={participantProfileImageUrls[0]}
+                                    className="size-10 border-4 border-white -translate-x-2"
+                                />
+                            )}
+                            {participantProfileImageUrls.length >= 2 && (
+                                <Profile
+                                    imageUrl={participantProfileImageUrls[1]}
+                                    className="size-10 border-4 border-white"
+                                />
+                            )}
+                            {participantProfileImageUrls.length > 2 ? (
+                                <Plus size={14} className="translate-x-26" />
+                            ) : (
+                                <></>
+                            )}
+                        </div>
+                    </CardFooter>
+                </Card>
+            </li>
+
+            <TaskDetailModal
+                isOpen={isTaskViewerModalOpen}
+                onClose={() => setIsTaskViewerModalOpen(false)}
+            />
+        </>
     );
 };
 

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -1,119 +1,131 @@
+"use client";
+
 import Button from "@/components/Button";
 import Input from "@/components/Input";
 import PageHeader from "@/components/PageHeader";
-
 import VerticalDropbox from "@/components/VerticalDropbox";
 import StateSection from "./StateSection";
 import { StateDataProps } from "./type";
+import { useState } from "react";
+import TaskCreateModal from "@/components/task/TaskEditorModal";
+
+const options = [
+    {
+        label: "제목",
+        value: "title",
+    },
+    {
+        label: "중요도",
+        value: "priority",
+    },
+    {
+        label: "사용자명",
+        value: "name",
+    },
+];
+
+type BoardData = {
+    todo: StateDataProps[];
+    inProgress: StateDataProps[];
+    completed: StateDataProps[];
+};
+
+const data: BoardData = {
+    todo: [
+        {
+            taskId: 10,
+            title: "로그인 페이지 UI",
+            label: {
+                labelName: "HIGH",
+                color: "RED",
+            },
+            assigneeProfileImageUrl: "https://...",
+            participantProfileImageUrls: [
+                "https://...",
+                "https://...",
+                "https://...",
+            ],
+            commentCount: 3,
+        },
+        {
+            taskId: 11,
+            title: "로그인 페이지 UI",
+            label: {
+                labelName: "HIGH",
+                color: "RED",
+            },
+            assigneeProfileImageUrl: "https://...",
+            participantProfileImageUrls: [],
+            commentCount: 3,
+        },
+    ],
+    inProgress: [
+        {
+            taskId: 8,
+            title: "로그인 페이지 UI",
+            label: {
+                labelName: "LOW",
+                color: "GRAY",
+            },
+            assigneeProfileImageUrl: "https://...",
+            participantProfileImageUrls: ["https://..."],
+            commentCount: 3,
+        },
+    ],
+
+    completed: [
+        {
+            taskId: 4,
+            title: "로그인 페이지 UI",
+            label: {
+                labelName: "MEDIUM",
+                color: "YELLOW",
+            },
+            assigneeProfileImageUrl: "https://...",
+            participantProfileImageUrls: ["https://..."],
+            commentCount: 3,
+        },
+    ],
+};
 
 const Board = () => {
-    const options = [
-        {
-            label: "제목",
-            value: "title",
-        },
-        {
-            label: "중요도",
-            value: "label",
-        },
-        {
-            label: "사용자명",
-            value: "name",
-        },
-    ];
-
-    type BoardData = {
-        todo: StateDataProps[];
-        inProgress: StateDataProps[];
-        completed: StateDataProps[];
-    };
-
-    const data: BoardData = {
-        todo: [
-            {
-                taskId: 10,
-                title: "로그인 페이지 UI",
-                label: {
-                  labelName: "HIGH",
-                  color: "RED"
-                },
-                assigneeProfileImageUrl: "https://...",
-                participantProfileImageUrls: [
-                    "https://...",
-                    "https://...",
-                    "https://...",
-                ],
-                commentCount: 3,
-            },
-            {
-                taskId: 11,
-                title: "로그인 페이지 UI",
-                label: {
-                  labelName: "MEDIUM",
-                  color: "YELLOW"
-                },
-                assigneeProfileImageUrl: "https://...",
-                participantProfileImageUrls: [],
-                commentCount: 3,
-            },
-        ],
-        inProgress: [
-            {
-                taskId: 8,
-                title: "로그인 페이지 UI",
-                label: {
-                  labelName: "MEDIUM",
-                  color: "YELLOW"
-                },
-                assigneeProfileImageUrl: "https://...",
-                participantProfileImageUrls: ["https://..."],
-                commentCount: 3,
-            },
-        ],
-
-        completed: [
-            {
-                taskId: 4,
-                title: "로그인 페이지 UI",
-                label: {
-                  labelName: "LOW",
-                  color: "GRAY"
-                },
-                assigneeProfileImageUrl: "https://...",
-                participantProfileImageUrls: ["https://..."],
-                commentCount: 3,
-            },
-        ],
-    };
+    const [isTaskEditorModalOpen, setIsTaskEditorModalOpen] = useState(false);
 
     return (
-        <main>
-            <PageHeader
-                className="px-14"
-                left="Board"
-                center={
-                    <div className="flex items-center">
-                        <VerticalDropbox
-                            options={options}
-                            className="mr-2 py-4.5 size-26"
+        <>
+            <main>
+                <PageHeader
+                    className="px-14"
+                    left="Board"
+                    center={
+                        <div className="flex items-center">
+                            <VerticalDropbox
+                                options={options}
+                                className="mr-2 py-4.5 size-26"
+                            />
+                            <Input search />
+                        </div>
+                    }
+                    right={
+                        <Button
+                            label="+ task 생성"
+                            size="sm"
+                            className="font-bold px-4"
+                            onClick={() => setIsTaskEditorModalOpen(true)}
                         />
-                        <Input search />
-                    </div>
-                }
-                right={
-                    <Button
-                        label="+ task 생성"
-                        size="sm"
-                        className="font-bold px-4"
-                    />
-                }
+                    }
+                />
+                <div className="w-full mx-auto px-20 pt-4 flex gap-8 xl:gap-16 justify-between">
+                    <StateSection status="To do" tasks={data.todo} />
+                    <StateSection status="In Progress" tasks={data.inProgress} />
+                    <StateSection status="Completed" tasks={data.completed} />
+                </div>
+            </main>
+            <TaskCreateModal
+                isOpen={isTaskEditorModalOpen}
+                onClose={() => setIsTaskEditorModalOpen(false)}
             />
-            <div className="w-full mx-auto px-20 pt-4 flex gap-8 xl:gap-16 justify-between">
-                <StateSection state="To do" tasks={data.todo} />
-                <StateSection state="In Progress" tasks={data.inProgress} />
-                <StateSection state="Completed" tasks={data.completed} />
-            </div>
-        </main>
+        </>
     );
 };
 

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,6 +1,13 @@
 import { cn } from "../lib/utils";
 
-export type LabelVariant = "default" | "red" | "blue" | "green" | "black" | "white" | "yellow";
+export type LabelVariant =
+    | "default"
+    | "red"
+    | "blue"
+    | "green"
+    | "black"
+    | "white"
+    | "yellow";
 type size = "xs" | "sm" | "md";
 
 interface LabelProps {
@@ -9,6 +16,7 @@ interface LabelProps {
     size?: size;
     className?: string;
     leftIcon?: React.ReactNode;
+    rightIcon?: React.ReactNode;
     onClick?: () => void;
 }
 
@@ -25,7 +33,7 @@ const variantClasses: Record<LabelVariant, string> = {
     green: "bg-sub4/40 text-green-600",
     black: "bg-gray5 text-white",
     white: "bg-white border text-black",
-    yellow: "bg-yellow-200/70  text-yellow-600"
+    yellow: "bg-yellow-200/70  text-yellow-600",
 };
 
 const Label = ({
@@ -34,6 +42,7 @@ const Label = ({
     size = "sm",
     className,
     leftIcon,
+    rightIcon,
     onClick,
 }: LabelProps) => {
     const Component = onClick ? "button" : "div";
@@ -50,13 +59,12 @@ const Label = ({
             type={onClick ? "button" : undefined}
             onClick={onClick}
         >
-            {leftIcon ? (
-                <span className="flex items-center gap-2">
-                    {leftIcon}
-                    {text}
-                </span>
-            ) : (
-                <span>{text}</span>
+            <span className="flex items-center gap-2">
+                {leftIcon && leftIcon}
+                {text}
+            </span>
+            {rightIcon && (
+                <span className="flex items-center">{rightIcon}</span>
             )}
         </Component>
     );

--- a/src/components/modal/UserInfoModal.tsx
+++ b/src/components/modal/UserInfoModal.tsx
@@ -6,60 +6,65 @@ import { UserInfoModalProps } from "./type";
 import BaseModal from "./BaseModal";
 
 const sizeClasses = {
-  sm: "max-w-md min-h-[300px]",
-  md: "max-w-lg min-h-[400px]",
-  lg: "max-w-2xl min-h-[500px]",
+    sm: "max-w-md min-h-[300px]",
+    md: "max-w-lg min-h-[400px]",
+    lg: "max-w-2xl min-h-[500px]",
 };
 
 export default function UserInfoModal({
-  isOpen,
-  onClose,
-  title,
-  children,
-  footer,
-  size = "sm",
-  closeOnOverlayClick = true,
-  closeOnEsc = true,
-  showCloseButton = true,
-  className,
+    isOpen,
+    onClose,
+    title,
+    children,
+    footer,
+    size = "sm",
+    closeOnOverlayClick = true,
+    closeOnEsc = true,
+    showCloseButton = true,
+    className,
+    titleNode,
 }: UserInfoModalProps) {
-  return (
-    <BaseModal
-      isOpen={isOpen}
-      onClose={onClose}
-      closeOnOverlayClick={closeOnOverlayClick}
-      closeOnEsc={closeOnEsc}
-      className={cn(sizeClasses[size], className)}
-    >
-      {/* 헤더 */}
-      {(title || showCloseButton) && (
-        <div className="flex items-center justify-between px-6 py-6">
-          {title && (
-            <h2 id="modal-title" className="text-lg font-semibold text-gray5">
-              {title}
-            </h2>
-          )}
-          {showCloseButton && (
-            <button
-              onClick={onClose}
-              className="ml-auto text-gray4 hover:text-gray5 hover:bg-gray2 transition-colors rounded-full p-1.5"
-              aria-label="모달 닫기"
-            >
-              <X size={20} />
-            </button>
-          )}
-        </div>
-      )}
+    return (
+        <BaseModal
+            isOpen={isOpen}
+            onClose={onClose}
+            closeOnOverlayClick={closeOnOverlayClick}
+            closeOnEsc={closeOnEsc}
+            className={cn(sizeClasses[size], className)}
+        >
+            {/* 헤더 */}
+            {(title || showCloseButton) && (
+                <div className="flex items-center justify-between px-6 py-6">
+                    {title && (
+                        <h2
+                            id="modal-title"
+                            className="text-lg font-semibold text-gray5"
+                        >
+                            {title}
+                        </h2>
+                    )}
+                    {titleNode && titleNode}
+                    {showCloseButton && (
+                        <button
+                            onClick={onClose}
+                            className="ml-auto text-gray4 hover:text-gray5 hover:bg-gray2 transition-colors rounded-full p-1.5"
+                            aria-label="모달 닫기"
+                        >
+                            <X size={20} />
+                        </button>
+                    )}
+                </div>
+            )}
 
-      {/* 본문 */}
-      <div className="px-6 py-6 overflow-y-auto">{children}</div>
+            {/* 본문 */}
+            <div className={cn(titleNode ? "pt-2 pb-6" : "py-6", "px-6 overflow-y-auto")}>{children}</div>
 
-      {/* 푸터 */}
-      {footer && (
-        <div className="px-6 py-4 border-t border-gray2 bg-gray1/30">
-          {footer}
-        </div>
-      )}
-    </BaseModal>
-  );
+            {/* 푸터 */}
+            {footer && (
+                <div className="px-6 py-4 border-t border-gray2 bg-gray1/30">
+                    {footer}
+                </div>
+            )}
+        </BaseModal>
+    );
 }

--- a/src/components/modal/type.ts
+++ b/src/components/modal/type.ts
@@ -36,4 +36,5 @@ export interface UserInfoModalProps {
   closeOnEsc?: boolean;
   showCloseButton?: boolean;
   className?: string;
+  titleNode?: React.ReactNode;
 }

--- a/src/components/participant/type.ts
+++ b/src/components/participant/type.ts
@@ -6,6 +6,6 @@ export interface Participant {
     email: string;
     profileImageUrl: string | null;
     role: string;
-    removable: boolean;
-    isExisting: boolean;
+    removable?: boolean;
+    isExisting?: boolean;
 }

--- a/src/components/popover/PopoverActionItem.tsx
+++ b/src/components/popover/PopoverActionItem.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
     Popover,
     PopoverAnchor,
@@ -5,10 +7,11 @@ import {
     PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { useState } from "react";
 
 interface PopoverActionItemProps {
     trigger: React.ReactNode;
-    content: React.ReactNode;
+    content: (close: () => void) => React.ReactNode;
     contentWidth?: string;
     className?: string;
 }
@@ -19,13 +22,18 @@ const PopoverActionItem = ({
     contentWidth = "w-fit",
     className,
 }: PopoverActionItemProps) => {
+    const [open, setOpen] = useState(false);
+
+    // 선택 시 popover close
+    const close = () => setOpen(false);
+
+    const render = typeof content === "function" ? content(close) : content;
+
     return (
-        <Popover>
+        <Popover open={open} onOpenChange={setOpen}>
             <PopoverAnchor asChild>
                 <div className="inline-flex items-center gap-2 cursor-pointer">
-                    <PopoverTrigger asChild>
-                        {trigger}
-                    </PopoverTrigger>
+                    <PopoverTrigger asChild>{trigger}</PopoverTrigger>
                 </div>
             </PopoverAnchor>
             <PopoverContent
@@ -33,7 +41,7 @@ const PopoverActionItem = ({
                 side="bottom"
                 className={cn(contentWidth, className)}
             >
-                {content}
+                {render}
             </PopoverContent>
         </Popover>
     );

--- a/src/components/popover/PopoverDropbox.tsx
+++ b/src/components/popover/PopoverDropbox.tsx
@@ -1,16 +1,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import Label from "../Label";
-import { LabelVariant } from "@/components/Label";
-
-interface PopoverDropboxOption {
-    id: string;
-    label: string;
-    variant?: LabelVariant;
-    leftIcon?: React.ReactNode; // 프로필 이미지, leftIcon 위치
-    onClick?: () => void;
-}
-
+import { PopoverDropboxOption } from "./type";
 interface PopoverDropboxProps {
     options: PopoverDropboxOption[];
     className?: string;
@@ -37,8 +28,8 @@ const PopoverDropbox = ({
             >
                 {options.map((option) => (
                     <Label
-                        key={option.id}
-                        label={option.label}
+                        key={option.value}
+                        text={option.label}
                         variant={option.variant}
                         leftIcon={option.leftIcon}
                         onClick={option.onClick}

--- a/src/components/popover/type.ts
+++ b/src/components/popover/type.ts
@@ -1,0 +1,9 @@
+import { LabelVariant } from "../Label";
+
+export interface PopoverDropboxOption {
+    value: string;
+    label: string;
+    variant?: LabelVariant;
+    leftIcon?: React.ReactNode;
+    onClick?: () => void;
+}

--- a/src/components/task/TaskEditorModal.tsx
+++ b/src/components/task/TaskEditorModal.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import UserInfoModal from "../modal/UserInfoModal";
+import Button from "../Button";
+import { PenLine, Settings2, Tag, UserRound, UserStar } from "lucide-react";
+import Label from "../Label";
+import Profile from "../Profile";
+import TaskPopoverSelect from "./TaskPopoverSelect";
+import TaskParticipantSelect from "./TaskParticipantSelect";
+import { Participant } from "../participant/type";
+import { LABEL_OPTIONS } from "@/components/task/labelOptions";
+import { LabelName } from "@/app/board/type";
+
+type TaskStatus = "TODO" | "IN_PROGRESS" | "COMPLETED";
+
+interface TaskEditorModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const data: Participant[] = [
+    {
+        userId: 2,
+        name: "홍길동",
+        email: "aaa@example.com",
+        profileImageUrl: "https://...",
+        role: "LEADER",
+    },
+    {
+        userId: 3,
+        name: "김아무개",
+        email: "bbb@example.com",
+        profileImageUrl: "https://...",
+        role: "MEMBER",
+    },
+];
+
+const TaskEditorModal = ({ isOpen, onClose }: TaskEditorModalProps) => {
+    const [title, setTitle] = useState("");
+    const [status, setStatus] = useState<TaskStatus | undefined>(undefined);
+    const [label, setLabel] = useState<LabelName | undefined>(undefined);
+    const [participantIds, setParticipantIds] = useState<number[]>([]);
+    const [description, setDescription] = useState("");
+
+    const submitHandler = () => {
+        console.log("동작");
+    };
+
+    return (
+        <UserInfoModal
+            isOpen={isOpen}
+            onClose={onClose}
+            className="max-w-2xl max-h-[800px] overflow-y-auto"
+            titleNode={
+                <input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="업무 제목을 입력하세요"
+                    className="w-full text-lg font-bold outline-none"
+                />
+            }
+        >
+            <div>
+                <div className="grid grid-cols-[80px_1fr] gap-x-10 gap-y-4 pb-6 border-b">
+                    <span className="inline-flex items-center text-gray4">
+                        <Settings2 size={18} className="mr-2" /> 상태
+                    </span>
+                    <div>
+                        <TaskPopoverSelect
+                            value={status}
+                            onChange={setStatus}
+                            placeholder="+ 상태 선택"
+                            variant="white"
+                            options={[
+                                { value: "TODO", label: "To do" },
+                                { value: "IN_PROGRESS", label: "In Progress" },
+                                { value: "COMPLETED", label: "Completed" },
+                            ]}
+                        />
+                    </div>
+                    <span className="inline-flex items-center text-gray4">
+                        <Tag size={18} className="mr-2" /> 중요도
+                    </span>
+                    <div>
+                        <TaskPopoverSelect
+                            value={label}
+                            onChange={setLabel}
+                            placeholder="+ 중요도 선택"
+                            options={LABEL_OPTIONS}
+                        />
+                    </div>
+                    <span className="inline-flex items-center text-gray4">
+                        <UserStar size={18} className="mr-2" /> 담당자
+                    </span>
+                    <div>
+                        {/* 현재 담당자 - Task 만드는 사람 */}
+                        <Label
+                            text="Lee minjeong"
+                            leftIcon={
+                                <Profile
+                                    className="size-4
+                    "
+                                />
+                            }
+                            variant="white"
+                            size="sm"
+                            className="py-1"
+                        />
+                    </div>
+                    <span className="inline-flex items-center text-gray4">
+                        <UserRound size={18} className="mr-2" /> 참여자
+                    </span>
+                    <div className="flex flex-wrap gap-2">
+                        <TaskParticipantSelect
+                            participants={data}
+                            selectedUserIds={participantIds}
+                            onChange={setParticipantIds}
+                            placeholder="+ 참여자 선택"
+                        />
+                    </div>
+                </div>
+                <div className="min-h-[200px] pt-4 border-b">
+                    <span className="block text-gray4 pb-2">설명</span>
+                    <textarea
+                        placeholder="여기에 설명을 적어주세요"
+                        className="inline-flex text-sm text-gray5 w-full min-h-[140px]"
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                    ></textarea>
+                </div>
+                <div className="flex justify-end gap-2 pt-5">
+                    <Button
+                        type="submit"
+                        icon={<PenLine size={14} />}
+                        variant="disable"
+                        label="저장"
+                        onClick={submitHandler}
+                    />
+                </div>
+            </div>
+        </UserInfoModal>
+    );
+};
+
+export default TaskEditorModal;

--- a/src/components/task/TaskParticipantSelect.tsx
+++ b/src/components/task/TaskParticipantSelect.tsx
@@ -1,0 +1,124 @@
+import { Minus } from "lucide-react";
+import Button from "../Button";
+import Label from "../Label";
+import { Participant } from "../participant/type";
+import PopoverActionItem from "../popover/PopoverActionItem";
+import PopoverDropbox from "../popover/PopoverDropbox";
+import { PopoverDropboxOption } from "../popover/type";
+import Profile from "../Profile";
+
+interface TaskParticipantSelectProps {
+    participants: Participant[];
+    selectedUserIds: number[];
+    onChange: (ids: number[]) => void;
+    placeholder?: string;
+}
+
+const TaskParticipantSelect = ({
+    participants,
+    selectedUserIds,
+    onChange,
+    placeholder = " + 참여자 선택",
+}: TaskParticipantSelectProps) => {
+    // 선택된 참여자
+    const selected = participants.filter((participant) =>
+        selectedUserIds.includes(participant.userId)
+    );
+
+    // 선택되지 않은 참여자
+    const available = participants.filter(
+        (participant) => !selectedUserIds.includes(participant.userId)
+    );
+
+    // 아직 남은 참여자가 있는지 여부
+    const selectMore = available.length > 0;
+
+    const selectHandler = (userId: number) => {
+        onChange([...selectedUserIds, userId]);
+    };
+
+    const removeHandler = (userId: number) => {
+        onChange(selectedUserIds.filter((id) => id !== userId));
+    };
+
+    const options: PopoverDropboxOption[] = available.map((p) => ({
+        value: String(p.userId),
+        label: p.name,
+        leftIcon: p.profileImageUrl && (
+            <Profile className="size-4" imageUrl={p.profileImageUrl} />
+        ),
+        onClick: () => selectHandler(p.userId),
+    }));
+
+    const SelectedLabels = (
+        <div className="flex flex-wrap gap-1">
+            {selected.map((p) => (
+                <Label
+                    key={p.userId}
+                    text={p.name}
+                    size="sm"
+                    leftIcon={
+                        p.profileImageUrl && (
+                            <Profile
+                                className="size-4"
+                                imageUrl={p.profileImageUrl}
+                            />
+                        )
+                    }
+                    rightIcon={
+                        <Button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                removeHandler(p.userId);
+                            }}
+                            className="absolute -top-1 rounded-ful p-1"
+                            variant="disable"
+                            icon={
+                                <Minus
+                                    size={5}
+                                    strokeWidth={4}
+                                />
+                            }
+                        />
+                    }
+                    variant="white"
+                    className="relative"
+                />
+            ))}
+        </div>
+    );
+
+    if (!selectMore) {
+        return SelectedLabels;
+    }
+
+    return (
+        <PopoverActionItem
+            trigger={
+                <div className="flex flex-wrap gap-1">
+                    {SelectedLabels.props.children}
+                    <Button
+                        size="sm"
+                        variant="white"
+                        label={placeholder}
+                        className="text-[12px] py-1.5 text-gray3"
+                    />
+                </div>
+            }
+            content={(close) => (
+                <PopoverDropbox
+                    options={options.map((option) => ({
+                        ...option,
+                        variant: "white",
+                        onClick: () => {
+                            option.onClick?.();
+                            close();
+                        },
+                    }))}
+                />
+            )}
+        />
+    );
+};
+
+export default TaskParticipantSelect;

--- a/src/components/task/TaskPopoverSelect.tsx
+++ b/src/components/task/TaskPopoverSelect.tsx
@@ -1,0 +1,67 @@
+import Button from "../Button";
+import Label, { LabelVariant } from "../Label";
+import PopoverActionItem from "../popover/PopoverActionItem";
+import PopoverDropbox from "../popover/PopoverDropbox";
+
+export interface SelectOption<T extends string> {
+  value: T;
+  label: string;
+  variant? : LabelVariant;
+  onClick?: () => void;
+};
+
+interface TaskPopoverSelectProp<T extends string> {
+    value?: T; // value 값이 확실하게 string 값이도록
+    placeholder: string;
+    onChange: (value: T) => void;
+    options: ReadonlyArray<SelectOption<T>>;
+    variant?: LabelVariant;
+}
+
+const TaskPopoverSelect = <T extends string>({
+    value,
+    placeholder,
+    onChange,
+    options,
+    variant,
+}: TaskPopoverSelectProp<T>) => {
+    const selected = value
+        ? options.find((option) => option.value === value)
+        : undefined;
+
+    return (
+        <PopoverActionItem
+            trigger={
+                selected ? (
+                    <Label
+                        text={selected.label}
+                        size="sm"
+                        variant={selected.variant || variant}
+                    />
+                ) : (
+                    <Button
+                        size="sm"
+                        variant="white"
+                        label={placeholder}
+                        className="text-[12px] py-1.5 text-gray3"
+                    />
+                )
+            }
+            content={(close) => (
+                <PopoverDropbox
+                    options={options.map((option) => ({
+                        value: option.value,
+                        label: option.label,
+                        variant: option.variant,
+                        onClick: () => {
+                            onChange(option.value);
+                            close();
+                        },
+                    }))}
+                />
+            )}
+        ></PopoverActionItem>
+    );
+};
+
+export default TaskPopoverSelect;

--- a/src/components/task/TaskViewerModal.tsx
+++ b/src/components/task/TaskViewerModal.tsx
@@ -1,0 +1,183 @@
+import {
+    PenLine,
+    Settings2,
+    Tag,
+    Trash,
+    UserRound,
+    UserStar,
+} from "lucide-react";
+import Label from "../Label";
+import UserInfoModal from "../modal/UserInfoModal";
+import Profile from "../Profile";
+import Button from "../Button";
+
+interface TaskViewerModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const TaskViewerModal = ({ isOpen, onClose }: TaskViewerModalProps) => {
+
+    return (
+        <UserInfoModal
+            isOpen={isOpen}
+            onClose={onClose}
+            title={"새 업무"}
+            className="max-w-2xl max-h-[800px] overflow-y-auto"
+        >
+            <div>
+                <div className="grid grid-cols-[80px_1fr] gap-x-10 gap-y-4 pb-6 border-b">
+                    <span className="inline-flex items-center text-gray4">
+                        <Settings2 size={18} className="mr-2" /> 상태
+                    </span>
+                    <div>
+                        <Label
+                            text={"TODO"}
+                            variant="white"
+                            size="sm"
+                            className="py-1"
+                        />
+                    </div>
+                    <span className="inline-flex items-center text-gray4">
+                        <Tag size={18} className="mr-2" /> 중요도
+                    </span>
+                    <div>
+                        <Label
+                            text="HIGH"
+                            variant="red"
+                            size="sm"
+                            className="py-1"
+                        />
+                    </div>
+                    <span className="inline-flex items-center text-gray4">
+                        <UserStar size={18} className="mr-2" /> 담당자
+                    </span>
+                    <div>
+                        <Label
+                            text="Lee minjeong"
+                            leftIcon={
+                                <Profile
+                                    className="size-4
+                    "
+                                />
+                            }
+                            variant="white"
+                            size="sm"
+                            className="py-1"
+                        />
+                    </div>
+                    <span className="inline-flex items-center text-gray4">
+                        <UserRound size={18} className="mr-2" /> 참여자
+                    </span>
+                    <div className="flex flex-wrap gap-2">
+                        <Label
+                            text="Lee minjeong"
+                            leftIcon={
+                                <Profile
+                                    className="size-4
+                    "
+                                />
+                            }
+                            variant="white"
+                            size="sm"
+                            className="py-1"
+                        />
+                        <Label
+                            text="Lee minjeong"
+                            leftIcon={
+                                <Profile
+                                    className="size-4
+                    "
+                                />
+                            }
+                            variant="white"
+                            size="sm"
+                            className="py-1"
+                        />
+                        <Label
+                            text="Lee minjeong"
+                            leftIcon={
+                                <Profile
+                                    className="size-4
+                    "
+                                />
+                            }
+                            variant="white"
+                            size="sm"
+                            className="py-1"
+                        />
+                        <Label
+                            text="Lee minjeong"
+                            leftIcon={
+                                <Profile
+                                    className="size-4
+                    "
+                                />
+                            }
+                            variant="white"
+                            size="sm"
+                            className="py-1"
+                        />
+                    </div>
+                </div>
+                <div className="min-h-[200px] pt-4 border-b">
+                    <span className="inline-block text-gray4 pb-2">설명</span>
+                    <p className="text-sm text-gray5">
+                    </p>
+                </div>
+                <div className="flex justify-end gap-2 pt-5">
+                    <Button
+                        icon={<PenLine size={14} />}
+                        variant="disable"
+                        label="수정"
+                    />
+                    <Button
+                        icon={<Trash size={14} />}
+                        variant="disable"
+                        label="삭제"
+                    />
+                </div>
+            </div>
+            {/* 댓글 예시 */}
+            {/* <div>
+                <div className="px-2 py-4 grid grid-cols-[40px_1fr_50px] gap-x-4 items-center">
+                  <Profile size="sm" />
+                  <Input />
+                  <Button icon={<Send size={20} color="white" />} variant="primary"  />
+                </div>
+                <div className="pl-2 py-4">
+                  <h3 className="text-lg font-bold">COMMENT</h3>
+                  <div className="flex gap-4 py-2">
+                    <div className="mt-3">
+                       <Profile size="sm" />
+                    </div>
+                    <div>
+                      <span className="text-xs text-gray3">2025-11-13 12:00:00</span>
+                      <p className="text-sm">확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다. 확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다.확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다.확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다.</p>
+                    </div>
+                  </div>
+                  <div className="flex gap-4 py-2">
+                    <div className="mt-3">
+                       <Profile size="sm" />
+                    </div>
+                    <div>
+                      <span className="text-xs text-gray3">2025-11-13 12:00:00</span>
+                      <p className="text-sm">확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다. 확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다.확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다.확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다.</p>
+                    </div>
+                  </div>
+                  <div className="flex gap-4 py-2">
+                    <div className="mt-3">
+                       <Profile size="sm" />
+                    </div>
+                    <div>
+                      <span className="text-xs text-gray3">2025-11-13 12:00:00</span>
+                      <p className="text-sm">확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다. 확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다.확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다.확인했습니다, 추가적으로 더 회의를 진행해봐야겠습니다.</p>
+                    </div>
+                  </div>
+                </div>
+            </div> */}
+        </UserInfoModal>
+    );
+};
+
+export default TaskViewerModal;

--- a/src/components/task/labelOptions.ts
+++ b/src/components/task/labelOptions.ts
@@ -1,0 +1,9 @@
+import { LabelName } from "@/app/board/type";
+import { LabelVariant } from "@/components/Label";
+import { SelectOption } from "@/components/task/TaskPopoverSelect";
+
+export const LABEL_OPTIONS: ReadonlyArray<SelectOption<LabelName>> = [
+    { value: "HIGH", label: "HIGH", variant: "red" as LabelVariant },
+    { value: "MEDIUM", label: "MEDIUM", variant: "yellow" as LabelVariant },
+    { value: "LOW", label: "LOW", variant: "default" as LabelVariant },
+]


### PR DESCRIPTION
## 🔗 이슈
#43 

## ⚙️ 작업 내용
task editor, viewer 모달 UI 를 구현했습니다.
구현을 하며 일부 다른 컴포넌트 내에서 수정, 추가가 이뤄졌습니다.

### [ UserInfoModal ]
ediotrModal 에서 제목을 입력할만한 Input 이 필요했고 titleNode props 로 받아 구현하였습니다.
또한 title, content 사이의 폭이 넓어 크기를 조정하였습니다.
#### before
UserInfoModal 내 Props 중 titleNode 없음
#### after
titleNode 추가
`{titleNode && titleNode}`
`<div className={cn(titleNode ? "pt-2 pb-6" : "py-6", "px-6 overflow-y-auto")}>{children}</div>`

### [ popover ]
기존에 만들었던 popover 는 dropbox 내 항목을 선택 시 popoverDropbox 가 close 되지 않고 외부를 클릭해야 닫혀서 사용자의 편의성을 고려하여 선택 시 닫히도록 구현하였습니다.

#### before
선택해도 dropbox 가 유지
#### after
`content: (close: () => void) => React.ReactNode;` 
content 에 close 함수를 인자로 전달 할 수 있도록 구현 -> setOpen(fasle)
```
content={(close) => (
                <PopoverDropbox
                    options={options.map((option) => ({
                        value: option.value,
                        label: option.label,
                        variant: option.variant,
                        onClick: () => {
                            onChange(option.value);
                            close();
                        },
                    }))}
                />
            )}
```

### [ label ]
label rightIcon

#### before
label 에 leftIocn 은 있지만 rightIcon 이 없어서 editor 컴포넌트에서 선택 사용자 삭제하기가 번거로워 구현하였습니다.
#### after
`rightIcon?: React.ReactNode;`

### [ 기타 ]
task 작업을 하면서 중요도 HIGH, MEDIUM, LOW 값과  컬러값이 중복으로 들어가서 우선 하나의 labelOptions.ts 에 정의하였습니다.

## 🗒️ 기타 참고사항
Editor 부분을 구현하면서 UserInfoModal, Label, Popover, Board 관련 컴포넌트 추가/수정하였습니다.
Viewer 는 완전 단순 UI 로만 이루어져있습니다.

<img width="683" height="570" alt="스크린샷 2025-11-28 오후 7 03 42" src="https://github.com/user-attachments/assets/8b37cf5d-d771-4e79-b0f0-15bba62d155e" />

