### PR TITLE
[#59] bug: 회원가입 시 이동이 되지 않은 현상 해결

### DIFF
--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -26,12 +26,20 @@ export default function SignupForm({ isVisible }: SignupFormProps) {
         mutationFn: signupRequest,
         onSuccess: () => {
             toast.success("회원가입이 완료됐습니다, 로그인을 해주세요");
-            router.replace("/login");
+            setTimeout(() => {
+                if (typeof window !== "undefined") {
+                    window.location.href = "/login";
+                }
+            }, 1500);
         },
         onError: (error: ApiError) => {
             const status = error.status;
             if (status === 400) {
-                toast.error(error.data || error.message || "입력값 검증에 실패했습니다. 정보를 다시 확인해주세요.");
+                toast.error(
+                    error.data ||
+                        error.message ||
+                        "입력값 검증에 실패했습니다. 정보를 다시 확인해주세요."
+                );
             } else {
                 toast.error("회원가입에 실패하였습니다");
             }
@@ -214,11 +222,7 @@ export default function SignupForm({ isVisible }: SignupFormProps) {
                             size="md"
                             fullWidth
                             className="mt-6"
-                            disabled={
-                                !agreedToTerms ||
-                                !name ||
-                                !password
-                            }
+                            disabled={!agreedToTerms || !name || !password}
                         />
                     </form>
 


### PR DESCRIPTION
## 🔗 이슈
#59 

## ⚙️ 작업 내용
/login 화면에서 회원가입 성공 시 /login 으로 이동해주는 router 가 정상적으로 동작하지 않아 새로고침 후 로그인을 보여주도록 수정하였습니다.

### before
useRouter() 를 사용하여 회원가입 시 /login 으로 이동하도록 구현
### after
toast 가 화면에 나타나고 이동되도록 setTimeout 을 사용하고, 새로고침 후 /login 으로 이동하도록 구현

## 🗒️ 기타 참고사항
없음
