### PR TITLE
[#95] feat: 회원 탈퇴(계정 삭제) API 연결 및 채팅방 히스토리 탈퇴 유저 fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@stomp/stompjs": "^7.2.1",
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-query-devtools": "^5.91.1",
@@ -317,6 +318,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@stomp/stompjs": "^7.2.1",
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-query-devtools": "^5.91.1",

--- a/src/app/inbox/MessageThread.tsx
+++ b/src/app/inbox/MessageThread.tsx
@@ -14,6 +14,8 @@ const MessageThread = ({ messages }: MessageThreadProps) => {
         <div className="flex flex-col min-h-full justify-end">
             {messages.map((msg) => {
                 const isMe = msg.sender?.userId === me?.userId;
+                const displayName = msg.sender?.name ?? "탈퇴한 사용자";
+                const initial = displayName.charAt(0);
 
                 return (
                     <div
@@ -27,13 +29,13 @@ const MessageThread = ({ messages }: MessageThreadProps) => {
                             <div className="flex items-start gap-2 max-w-[70%]">
                                 <Profile
                                     className="w-8 h-8 shrink-0 text-sm"
-                                    userName={msg.sender?.name.charAt(0)}
+                                    userName={initial}
                                     imageUrl={msg.sender?.profileImageUrl}
                                 />
 
                                 <div className="flex flex-col items-start">
                                     <span className="mb-1 text-sm text-gray5">
-                                        {msg.sender?.name}
+                                        {displayName}
                                     </span>
 
                                     <div className="bg-gray1/30 py-2.5 px-4 rounded-2xl">

--- a/src/app/inbox/type.ts
+++ b/src/app/inbox/type.ts
@@ -25,7 +25,7 @@ export interface ChatMessage {
     chatRoomId: number;
     sender: {
         userId: number;
-        name: string;
+        name: string | null;
         profileImageUrl?: string | null;
     };
     content: string;

--- a/src/app/mypage/DeactivateAccountSection.tsx
+++ b/src/app/mypage/DeactivateAccountSection.tsx
@@ -2,56 +2,82 @@
 
 import Button from "@/components/Button";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { userDeleteRequest } from "@/lib/auth/authApi";
+import { authCleanup } from "@/lib/auth/authCleanup";
+import { useAuthStore } from "@/store/useAuthStore";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 export default function DeactivateAccountSection() {
-  const handleDeactivateAccount = () => {
-    // 계정 비활성화 로직
-  };
+    const router = useRouter();
+    const queryClient = useQueryClient();
 
-  return (
-    <div className="bg-white rounded-lg shadow-sm p-6">
-      <h3 className="text-lg font-bold mb-2">회원탈퇴</h3>
-      <div className="flex items-center justify-between gap-2">
-        <p className="text-sm text-gray-600">
-          더 이상 저희 서비스를 이용하지 않으시겠습니까?
-        </p>
+    const { clearAuth } = useAuthStore();
 
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button label="Deactivate account" variant="danger" size="md" />
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>
-                정말로 계정을 비활성화하시겠습니까?
-              </AlertDialogTitle>
-              <AlertDialogDescription>
-                이 작업은 되돌릴 수 없습니다. 계정을 비활성화하면 모든 데이터가
-                삭제되며 복구할 수 없습니다.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>취소</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={handleDeactivateAccount}
-                className="bg-sub2 hover:bg-sub2/80 text-white"
-              >
-                계정 비활성화
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      </div>
-    </div>
-  );
+    const handleDeactivateAccount = async () => {
+        // 계정 비활성화 로직
+        try {
+            await userDeleteRequest(); 
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : "계정 비활성화에 실패하였습니다");
+            return;
+        }
+
+        clearAuth();
+        authCleanup(queryClient);
+        router.replace("/");
+    };
+
+    return (
+        <div className="bg-white rounded-lg shadow-sm p-6">
+            <h3 className="text-lg font-bold mb-2">회원탈퇴</h3>
+            <div className="flex items-center justify-between gap-2">
+                <p className="text-sm text-gray-600">
+                    더 이상 저희 서비스를 이용하지 않으시겠습니까?
+                </p>
+
+                <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                        <Button
+                            label="Deactivate account"
+                            variant="danger"
+                            size="md"
+                        />
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                        <AlertDialogHeader>
+                            <AlertDialogTitle>
+                                정말로 계정을 비활성화하시겠습니까?
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                                이 작업은 되돌릴 수 없습니다. 계정을
+                                비활성화하면 모든 데이터가 삭제되며 복구할 수
+                                없습니다.
+                            </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                            <AlertDialogCancel>취소</AlertDialogCancel>
+                            <AlertDialogAction
+                                onClick={handleDeactivateAccount}
+                                className="bg-sub2 hover:bg-sub2/80 text-white"
+                            >
+                                계정 비활성화
+                            </AlertDialogAction>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialog>
+            </div>
+        </div>
+    );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,7 @@ import { logoutRequest } from "@/lib/auth/authApi";
 import { toast } from "sonner";
 import useMe from "@/lib/user/useMe";
 import { useQueryClient } from "@tanstack/react-query";
+import { authCleanup } from "@/lib/auth/authCleanup";
 
 interface HeaderProps {
     className?: string;
@@ -30,17 +31,14 @@ const Header = ({ className }: HeaderProps) => {
 
     const logoutHandler = async () => {
         try {
-            await logoutRequest();
+            await logoutRequest(); // 서버 로그아웃
         } catch (err) {
             console.error(err);
             toast.error("로그아웃 중 오류가 발생했습니다.");
         } finally {
             clearAuth();
-            queryClient.setQueryData(["me"], null);
-            queryClient.removeQueries({ queryKey: ["me"], exact: false });
-
+            authCleanup(queryClient);
             router.replace("/");
-            router.refresh();
         }
     };
 
@@ -73,7 +71,11 @@ const Header = ({ className }: HeaderProps) => {
                                     userName={me.name.charAt(0)}
                                 />
                             ) : (
-                                <Profile size="sm" userName={me.name.charAt(0)} className="text-sm" />
+                                <Profile
+                                    size="sm"
+                                    userName={me.name.charAt(0)}
+                                    className="text-sm"
+                                />
                             )}
                             <span className="flex flex-col justify-center text-main2">
                                 {me.name}

--- a/src/lib/auth/authApi.ts
+++ b/src/lib/auth/authApi.ts
@@ -1,3 +1,4 @@
+import { authFetch } from "./authFetch";
 import { AuthUser, getAccessToken } from "./authStorage";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -34,6 +35,12 @@ export class ApiError extends Error {
     status?: number;
     data?: string;
     code?: number;
+}
+
+interface deleteResponse {
+    statusCode: number;
+    message: string;
+    data: null;
 }
 
 export async function loginRequest({
@@ -115,4 +122,18 @@ export async function logoutRequest() {
         headers: token ? { Authorization: `Bearer ${token}` } : undefined,
         credentials: "include",
     });
+}
+
+export async function userDeleteRequest() {
+    const res = await authFetch("/api/users/me", { method: "DELETE" });
+
+    const body: deleteResponse = await res.json();
+
+    if (!res.ok || body.statusCode !== 200) {
+        const error = new ApiError(body?.message ?? "회원 탈퇴 실패");
+        error.status = res.status;
+        throw error;
+    }
+
+    return body;
 }

--- a/src/lib/auth/authCleanup.ts
+++ b/src/lib/auth/authCleanup.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from "@tanstack/react-query";
+
+
+// 로그아웃, 탈퇴 시 사용
+export function authCleanup(queryClient: QueryClient) {
+  localStorage.removeItem("accessToken");
+
+  queryClient.setQueryData(["me"], null);
+  queryClient.removeQueries({ queryKey: ["me"], exact: false });
+  queryClient.clear();
+}

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -3,7 +3,7 @@ import {
     getAccessToken,
     getAuthUser,
     saveAuth,
-    clearAuth as clearAuthStorage
+    clearAuth as clearAuthStorage,
 } from "@/lib/auth/authStorage";
 import { create } from "zustand";
 


### PR DESCRIPTION
## 🔗 이슈
#95 

## ⚙️ 작업 내용
- 회원 탈퇴 API 연결
- 유저 회원 탈퇴 시 탈퇴한 유저의 메세지가 남아있는 채팅방에 오류가 발생하여 오류 해결

### before
- 로그아웃 시 me 데이터를 삭제
- 채팅방 메세지 히스토리에서 msg.sender?.name.charAt(0) 로 Profile 이미지 처리 -> 회원 탈퇴 시 sender name, profile...url 값이 null 로 변경되어 name 값을 찾을 수 없음

### after
- 로그아웃뿐만 아니라 회원 탈퇴 시 동일한 코드가 들어가 authCleanup 함수 중복 코드 처리
- msg.sender?.name.charAt(0) 가 아닌 화면에 표시될 이름을 따로 만들어 오류가 나지 않도록 함
```
const displayName = msg.sender?.name ?? "탈퇴한 사용자";
const initial = displayName.charAt(0);
```


## 🗒️ 기타 참고사항
