### PR TITLE
[#119] fix: 소셜 회원탈퇴 시 /board 페이지에 남아있는 오류 수정

### DIFF
--- a/src/app/mypage/DeactivateAccountSection.tsx
+++ b/src/app/mypage/DeactivateAccountSection.tsx
@@ -38,7 +38,9 @@ export default function DeactivateAccountSection() {
         authCleanup(queryClient);
         clearAuth();
 
-        window.location.replace("/login");
+        setTimeout(() => {
+            window.location.replace("/login");
+        }, 300);
     };
 
     return (


### PR DESCRIPTION
## 🔗 이슈
#119 

## ⚙️ 작업 내용
소셜 회원 탈퇴 시 /login 이 아닌 /board 페이지에 남아있는 오류 수정

## 🗒️ 기타 참고사항
이후에도 안된다면 서버에서 수정하거나 미들웨어 수정 필요
