### PR TITLE
[#119] fix: token 이 없으면 무조건 /login 페이지로 보내지는 현상 수정

### DIFF
--- a/src/app/AuthInitializer.tsx
+++ b/src/app/AuthInitializer.tsx
@@ -3,16 +3,12 @@
 import { useEffect } from "react";
 import { useAuthStore } from "@/store/useAuthStore";
 import { reissueAccessToken } from "@/lib/auth/authFetch";
-import { useRouter } from "next/navigation";
 import { getAccessToken } from "@/lib/auth/authStorage";
 import { fetchMe } from "@/lib/user/userApi";
-import { authCleanup } from "@/lib/auth/authCleanup";
-import { useQueryClient } from "@tanstack/react-query";
+
 
 export function AuthInitializer({ children }: { children: React.ReactNode }) {
-    const { initialize, setAuth, clearAuth } = useAuthStore();
-    const router = useRouter();
-    const queryClient = useQueryClient();
+    const { initialize, setAuth } = useAuthStore();
 
     useEffect(() => {
         const init = async () => {
@@ -23,17 +19,11 @@ export function AuthInitializer({ children }: { children: React.ReactNode }) {
 
             const newToken = await reissueAccessToken();
             if (!newToken) {
-                authCleanup(queryClient);
-                clearAuth();
-                router.replace("/login");
                 return;
             }
 
             const user = await fetchMe(newToken);
             if (!user) {
-                authCleanup(queryClient);
-                clearAuth();
-                router.replace("/login");
                 return;
             }
 
@@ -41,7 +31,7 @@ export function AuthInitializer({ children }: { children: React.ReactNode }) {
         };
 
         init();
-    }, [initialize, setAuth, clearAuth, router, queryClient]);
+    }, [initialize, setAuth]);
 
     return <>{children}</>;
 }


### PR DESCRIPTION
## 🔗 이슈
#119 

## ⚙️ 작업 내용
/login 으로 가지 않도록 수정

### before
```authCleanup(queryClient);
    clearAuth();
    router.replace("/login");```

### after
지우고 그냥 return

## 🗒️ 기타 참고사항
리뷰어가 알아야할 내용 등 참고사항을 작성
